### PR TITLE
🇮🇹 fix using.update

### DIFF
--- a/src/util/UsingWrapper.js
+++ b/src/util/UsingWrapper.js
@@ -4,12 +4,14 @@ import * as lang from '../lang'
 import * as math from '../math'
 import * as object from '../object'
 
-import at from 'lodash/at'
 import concat from 'lodash/concat'
+import drop from 'lodash/drop'
+import get from 'lodash/get'
+import head from 'lodash/head'
+import isSymbol from 'lodash/isSymbol'
 import map from 'lodash/map'
 import mapValues from 'lodash/mapValues'
 import omit from 'lodash/omit'
-import toPath from 'lodash/toPath'
 
 /**
  * Wrapper allowing to specify one or several paths to use as arguments for an immutadot function call.<br/>
@@ -29,20 +31,38 @@ class UsingWrapper {
    * @since 0.1.12
    */
   constructor(...paths) {
-    this._paths = map(paths, toPath)
+    this._paths = paths
   }
+
+  /**
+   * Argument placeholder.
+   * @since 0.2.1
+   */
+  static placeholder = Symbol.for('immutadot.using.placeholder')
 
   /**
    * Call a function with the specified arguments and possibly some more arguments.
    * @param {function} fn The function to call.
    * @param {Object} object The object to modify.
    * @param {Array|string} path The path of the property to be set.
-   * @param {...*} args The arguments for the function call.
+   * @param {Array} pArgs The arguments for the function call.
    * @return {Object} Returns the updated object.
    * @since 0.1.12
    */
-  _call(fn, object, path, args) {
-    return fn(object, path, ...concat(at(object, this._paths), args))
+  _call(fn, object, path, pArgs) {
+    let callArgs = pArgs
+    const args = concat(
+      map(this._paths, usingPath => {
+        if (isSymbol(usingPath)) {
+          const arg = head(callArgs)
+          callArgs = drop(callArgs)
+          return arg
+        }
+        return get(object, usingPath)
+      }),
+      callArgs
+    )
+    return fn(object, path, ...args)
   }
 }
 

--- a/src/util/using.js
+++ b/src/util/using.js
@@ -20,8 +20,10 @@ const using = (...paths) => new UsingWrapper(...paths)
 
 const { placeholder } = UsingWrapper
 using.placeholder = placeholder
+using._ = placeholder
 
 export {
   placeholder,
+  placeholder as _,
   using as default,
 }

--- a/src/util/using.js
+++ b/src/util/using.js
@@ -1,19 +1,27 @@
 import UsingWrapper from './UsingWrapper'
 
 /**
- * Allows to specify one or several paths to use as arguments for an immutadot function call.
+ * Allows to specify one or several paths to use as arguments for an immutadot function call.<br/>
+ * <code>using.placeholder</code> may be used to insert a passed argument before a path argument (see second example).
  * @function
  * @memberof util
  * @param {...(Array|string)} paths The paths to use as arguments.
  * @return {Object} Returns an object with immutadot functions.
- * @example <caption>Add <code>b</code> to <code>a</code></caption>
+ * @example <caption>Push <code>b</code>, <code>c</code> and <code>4</code> to <code>a</code></caption>
+ * const o = { nested: { a: [1], b: 2, c: 3 } }
+ * using('nested.b', 'nested.c').push(o, 'nested.a', 4) // => { nested: { a: [1, 2, 3, 4], b: 2, c: 3 } }
+ * @example <caption>Replace <code>a</code> by <code>a * b + 4</code> (use placeholder to send <code>updater</code> as first argument)</caption>
  * const o = { nested: { a: 2, b: 3 } }
- * using('nested.b').add(o, 'nested.a') // => { nested: { a: 5, b: 3 } }
- * @example <caption>Replace <code>a</code> by <code>a * b + c</code></caption>
- * const o = { nested: { a: 2, b: 3, c: 4 } }
- * using('nested.b', 'nested.c')
- *   .update(o, 'nested.a', (a, b, c) => a * b + c) // => { nested: { a: 10, b: 3, c: 4 } }
+ * using(using.placeholder, 'nested.b')
+ *   .update(o, 'nested.a', (a, b, c) => a * b + c, 4) // => { nested: { a: 10, b: 3 } }
  * @since 0.1.12
  */
 const using = (...paths) => new UsingWrapper(...paths)
-export default using
+
+const { placeholder } = UsingWrapper
+using.placeholder = placeholder
+
+export {
+  placeholder,
+  using as default,
+}

--- a/src/util/using.spec.js
+++ b/src/util/using.spec.js
@@ -38,13 +38,25 @@ describe('Using', () => {
         c: [1],
       },
     }
-    const output = using('nested.a', 'nested.b').push(input, 'nested.c')
+    const output = using('nested.a', 'nested.b').push(input, 'nested.c', 4)
     expect(output).toEqual({
       nested: {
         a: 2,
         b: 3,
-        c: [1, 2, 3],
+        c: [1, 2, 3, 4],
       },
+    })
+  })
+
+  it('should update a prop with another prop and a custom updater', () => {
+    const input = {
+      pages: [1, 2, 3],
+      selectedPages: [4, 5, 6],
+    }
+    const output = using('pages').update(input, 'selectedPages', (_, pages, start, end) => pages.slice(start, start + end), 1, 2)
+    expect(output).toEqual({
+      pages: [1, 2, 3],
+      selectedPages: [2, 3],
     })
   })
 })

--- a/src/util/using.spec.js
+++ b/src/util/using.spec.js
@@ -50,13 +50,22 @@ describe('Using', () => {
 
   it('should update a prop with another prop and a custom updater', () => {
     const input = {
-      pages: [1, 2, 3],
-      selectedPages: [4, 5, 6],
+      nested: {
+        a: 2,
+        b: 3,
+      },
     }
-    const output = using('pages').update(input, 'selectedPages', (_, pages, start, end) => pages.slice(start, start + end), 1, 2)
+    const output = using(using.placeholder, 'nested.b').update(
+      input,
+      'nested.a',
+      (a, b, c) => a * b + c,
+      4
+    )
     expect(output).toEqual({
-      pages: [1, 2, 3],
-      selectedPages: [2, 3],
+      nested: {
+        a: 10,
+        b: 3,
+      },
     })
   })
 })

--- a/src/util/using.spec.js
+++ b/src/util/using.spec.js
@@ -55,7 +55,7 @@ describe('Using', () => {
         b: 3,
       },
     }
-    const output = using(using.placeholder, 'nested.b').update(
+    const output = using(using._, 'nested.b').update(
       input,
       'nested.a',
       (a, b, c) => a * b + c,


### PR DESCRIPTION
### Description
`using.update` was using the first "using arg" as the updater.

Thx to @Taranys for the bug report.

**Issue :** #67

### Example usage
```js
    const input = {
      nested: {
        a: 2,
        b: 3,
      },
    }
    const output = using(using.placeholder, 'nested.b').update(
      input,
      'nested.a',
      (a, b, c) => a * b + c,
      4
    )
    expect(output).toEqual({
      nested: {
        a: 10,
        b: 3,
      },
    })
```
