### PR TITLE
Improve seq.chain

### DIFF
--- a/src/seq/ChainWrapper.js
+++ b/src/seq/ChainWrapper.js
@@ -4,8 +4,8 @@ import * as lang from '../lang'
 import * as math from '../math'
 import * as object from '../object'
 
+import _flow from 'lodash/flow'
 import concat from 'lodash/concat'
-import flow from 'lodash/flow'
 import mapValues from 'lodash/mapValues'
 import toPath from 'lodash/toPath'
 
@@ -25,13 +25,14 @@ class ChainWrapper {
    * Instances are created by calling {@link seq.chain}.
    * @param {Object} object The object to wrap.
    * @param {Array|string} [path] The path of the object on which functions are called.
+   * @param {Array} [flow=[]] Current calls flow.
    * @see {@link seq.chain} for more information.
    * @since 0.1.8
    */
-  constructor(object, path) {
+  constructor(object, path, flow = []) {
     this._object = object
     this._path = path
-    this._flow = []
+    this._flow = flow
   }
 
   /**
@@ -53,8 +54,11 @@ class ChainWrapper {
    * @since 0.1.8
    */
   _call(fn, path, args) {
-    this._flow.push(object => fn(object, this._absolutePath(path), ...args))
-    return this
+    return new ChainWrapper(
+      this._object,
+      this._path,
+      concat(this._flow, object => fn(object, this._absolutePath(path), ...args))
+    )
   }
 
   /**
@@ -69,7 +73,7 @@ class ChainWrapper {
    * @since 0.1.8
    */
   value() {
-    return flow(this._flow)(this._object)
+    return _flow(this._flow)(this._object)
   }
 }
 

--- a/src/seq/ChainWrapper.js
+++ b/src/seq/ChainWrapper.js
@@ -80,6 +80,21 @@ class ChainWrapper {
   }
 
   /**
+   * Executes the chain sequence and calls <code>callback</code> with the unwrapped object.
+   * @param {seq.peekCallback} callback Function to be called with the resolved unwrapped value.
+   * @returns {seq.ChainWrapper} The new wrapper instance.
+   * @todo Add an example.
+   * @since 0.3.0
+   */
+  peek(callback) {
+    const commited = this.commit()
+
+    callback(commited._wrapped)
+
+    return commited
+  }
+
+  /**
    * Executes the chain sequence and returns the unwrapped object.
    * @returns {Object} Returns the resolved unwrapped object.
    * @example
@@ -94,6 +109,14 @@ class ChainWrapper {
     return this.commit()._wrapped
   }
 }
+
+/**
+ * Function to be called by {@link seq.peek|peek} with the resolved unwrapped value.
+ * @memberof seq
+ * @callback peekCallback
+ * @param {Object} unwrapped The resolved unwrapped object
+ * @since 0.3.0
+ */
 
 // Add namespaces functions to the ChainWrapper prototype
 [

--- a/src/seq/chain.spec.js
+++ b/src/seq/chain.spec.js
@@ -42,4 +42,30 @@ describe('Chain', () => {
         },
       })
   })
+
+  it('should allow to peek in the middle of modifications', () => {
+    expect(chain(object)
+      .set('nested1.prop2', 'value5')
+      .peek(peeked => {
+        expect(peeked).toEqual({
+          nested1: {
+            prop1: 'value1',
+            prop2: 'value5',
+          },
+          nested2: {
+            prop3: 'value3',
+            prop4: 'value4',
+          },
+        })
+      })
+      .unset('nested2.prop4')
+      .value())
+      .toEqual({
+        nested1: {
+          prop1: 'value1',
+          prop2: 'value5',
+        },
+        nested2: { prop3: 'value3' },
+      })
+  })
 })

--- a/src/seq/index.js
+++ b/src/seq/index.js
@@ -4,6 +4,7 @@ import { chain } from './chain'
  * Sequence functions.
  * @namespace seq
  * @borrows seq.ChainWrapper#commit as #commit
+ * @borrows seq.ChainWrapper#peek as #peek
  * @borrows seq.ChainWrapper#value as #value
  * @since 0.1.8
  */

--- a/src/seq/index.js
+++ b/src/seq/index.js
@@ -3,6 +3,7 @@ import { chain } from './chain'
 /**
  * Sequence functions.
  * @namespace seq
+ * @borrows seq.ChainWrapper#commit as #commit
  * @borrows seq.ChainWrapper#value as #value
  * @since 0.1.8
  */


### PR DESCRIPTION
### Description
Improvements on `seq.chain` :
 * ChainWrapper becomes immutable (except the internal this._commited for optimization)
 * Add `commit` to execute the chain
 * Add `peek` to peek at the result during the chain
