### PR TITLE
:memo: node-sass on Windows troubleshooting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,7 @@ As immutad●t is still a very young project, we are also open to enhancement su
 #### Installation :package:
 We use [yarn](https://yarnpkg.com/) but you are free to use [npm](https://www.npmjs.com/) if you prefer.<br />
 Once you have cloned the project, run `yarn` or `npm install` to install all the dependencies.
+If you encounter trouble in the post-install phase involving `node-sass`, make sure you are building with VC++ 2013: `npm config set msvs_version 2013`.
 
 #### Architecture :house:
 We have only one peer dependency on [lodash](https://lodash.com/) and we intend to keep it that way.<br />

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ $ npm install immutadot
 
 or you can directly download [sources](https://github.com/Zenika/immutadot/releases).
 
+### `node-sass` + Windows troubleshooting
+
+If you encounter trouble in the post-install phase involving `node-sass`, make sure you are building with VC++ 2013: `npm config set msvs_version 2013`.
+
 ## Usage
 
 in browser:

--- a/README.md
+++ b/README.md
@@ -68,10 +68,6 @@ $ npm install immutadot
 
 or you can directly download [sources](https://github.com/Zenika/immutadot/releases).
 
-### `node-sass` + Windows troubleshooting
-
-If you encounter trouble in the post-install phase involving `node-sass`, make sure you are building with VC++ 2013: `npm config set msvs_version 2013`.
-
 ## Usage
 
 in browser:


### PR DESCRIPTION
### Prerequisites
- [X] I have read the [Contributing guidelines](https://github.com/Zenika/immutadot/blob/master/.github/CONTRIBUTING.md)
- [X] I have read the [Code of conduct](https://github.com/Zenika/immutadot/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description

Installation (`npm install` or `yarn install`) failed consistently when building `node-sass@3.13.0` required by `hotdoc@^0.7.2` required by `immutadot@master`. Latest Windows 10 x64, Node.js 8.2.1 or 8.4.0.

Reason: system was configured to build native packages using VC++ 2015. `node-sass` only became compatible with v2015 starting at `4.5.0`. Configuring npm to use VC++ 2013 for this project using `npm config set msvs_version 2013` fixed the problem.

