### PR TITLE
Refactoring of the string path syntax parser

### DIFF
--- a/packages/immutadot/src/core/parser.utils.js
+++ b/packages/immutadot/src/core/parser.utils.js
@@ -7,7 +7,7 @@ const maybeMap = (maybe, fn) => maybe === null ? maybe : fn(maybe)
 /**
  * Creates a parser from a regular expression by matching the input string with
  * the regular expression, returning the resulting match object.
- * 
+ * @function
  * @param {RegExp} regexp the regular expression
  * @return {Parser<string[]>} the resulting parser
  */
@@ -17,7 +17,7 @@ export const regexp = regexp => str => maybeMap(str.match(regexp), match => matc
  * Returns a new parser that will return <code>null</code> if a predicate about
  * the result of another parser does not hold. If the predicate holds then
  * the new parser returns the result of the other parser unchanged.
- * 
+ * @function
  * @param {Parser<T>} parser parser to filter
  * @param {function(*): boolean} predicate predicate to use
  * @return {Parser<T>} resulting parser
@@ -26,7 +26,7 @@ export const filter = (parser, predicate) => str => maybeMap(parser(str), parsed
 
 /**
  * Returns a new parser which will post-process the result of another parser.
- * 
+ * @function
  * @param {Parser<T>} parser parser for which to process the result
  * @param {function(T): R} mapper function to transform the result of the parser
  * @return {Parser<R>} resulting parser
@@ -36,7 +36,7 @@ export const map = (parser, mapper) => str => maybeMap(parser(str), mapper)
 /**
  * Returns a new parser that attempts parsing with a first parser then falls
  * back to a second parser if the first returns <code>null</code>.
- * 
+ * @function
  * @param {Parser<A>} parser the first parser
  * @param {Parser<B>} other the second parser
  * @return {Parser<A | B>} resulting parser
@@ -49,44 +49,8 @@ export const fallback = (parser, other) => str => {
 
 /**
  * Chains a list of parsers together using <code>fallback</code>.
- * 
- * @param {Parser<*>[]} parsers a list of parsers to try in order
+ * @function
+ * @param {Array<Parser<*>>} parsers a list of parsers to try in order
  * @return {Parser<*>} resulting parser
  */
 export const race = parsers => parsers.reduce((chainedParser, parser) => fallback(chainedParser, parser))
-
-// export class Parser {
-//   static from(fn) {
-//     return typeof fn === 'function'
-//       ? new Parser(fn)
-//       : new Parser(fn[Symbol.match].bind(fn))
-//   }
-
-//   static sequence(parsers) {
-//     return parsers.reduce((sequencedParser, parser) => sequencedParser.or(parser))
-//   }
-
-//   constructor(fn) {
-//     this.fn = fn
-//   }
-
-//   filter(predicate) {
-//     return Parser.from(str => {
-//       const matchResult = this.fn(str)
-//       if (matchResult === null) return matchResult
-//       return predicate(...matchResult) ? matchResult : null
-//     })
-//   }
-
-//   map(mapper) {
-//     return Parser.from(str => mapper(this.fn(str)))
-//   }
-
-//   or(otherParser) {
-//     return Parser.from(str => {
-//       const thisParserResult = this.fn(str)
-//       if (thisParserResult !== null) return thisParserResult
-//       return otherParser(str)
-//     })
-//   }
-// }

--- a/packages/immutadot/src/core/parser.utils.js
+++ b/packages/immutadot/src/core/parser.utils.js
@@ -1,5 +1,8 @@
 /**
  * @typedef {function(string): T | null} Parser<T>
+ * @memberof core
+ * @private
+ * @since 1.0.0
  */
 
 const maybeMap = (maybe, fn) => maybe === null ? maybe : fn(maybe)
@@ -8,8 +11,11 @@ const maybeMap = (maybe, fn) => maybe === null ? maybe : fn(maybe)
  * Creates a parser from a regular expression by matching the input string with
  * the regular expression, returning the resulting match object.
  * @function
+ * @memberof core
  * @param {RegExp} regexp the regular expression
- * @return {Parser<string[]>} the resulting parser
+ * @return {core.Parser<string[]>} the resulting parser
+ * @private
+ * @since 1.0.0
  */
 export const regexp = regexp => str => maybeMap(str.match(regexp), match => match.slice(1))
 
@@ -18,18 +24,24 @@ export const regexp = regexp => str => maybeMap(str.match(regexp), match => matc
  * the result of another parser does not hold. If the predicate holds then
  * the new parser returns the result of the other parser unchanged.
  * @function
- * @param {Parser<T>} parser parser to filter
+ * @memberof core
+ * @param {core.Parser<T>} parser parser to filter
  * @param {function(*): boolean} predicate predicate to use
- * @return {Parser<T>} resulting parser
+ * @return {core.Parser<T>} resulting parser
+ * @private
+ * @since 1.0.0
  */
 export const filter = (parser, predicate) => str => maybeMap(parser(str), parsed => predicate(parsed) ? parsed : null)
 
 /**
  * Returns a new parser which will post-process the result of another parser.
  * @function
- * @param {Parser<T>} parser parser for which to process the result
+ * @memberof core
+ * @param {core.Parser<T>} parser parser for which to process the result
  * @param {function(T): R} mapper function to transform the result of the parser
- * @return {Parser<R>} resulting parser
+ * @return {core.Parser<R>} resulting parser
+ * @private
+ * @since 1.0.0
  */
 export const map = (parser, mapper) => str => maybeMap(parser(str), mapper)
 
@@ -37,9 +49,12 @@ export const map = (parser, mapper) => str => maybeMap(parser(str), mapper)
  * Returns a new parser that attempts parsing with a first parser then falls
  * back to a second parser if the first returns <code>null</code>.
  * @function
- * @param {Parser<A>} parser the first parser
- * @param {Parser<B>} other the second parser
- * @return {Parser<A | B>} resulting parser
+ * @memberof core
+ * @param {core.Parser<A>} parser the first parser
+ * @param {core.Parser<B>} other the second parser
+ * @return {core.Parser<A | B>} resulting parser
+ * @private
+ * @since 1.0.0
  */
 export const fallback = (parser, other) => str => {
   const parsed = parser(str)
@@ -50,7 +65,10 @@ export const fallback = (parser, other) => str => {
 /**
  * Chains a list of parsers together using <code>fallback</code>.
  * @function
- * @param {Array<Parser<*>>} parsers a list of parsers to try in order
- * @return {Parser<*>} resulting parser
+ * @memberof core
+ * @param {Array<core.Parser<*>>} parsers a list of parsers to try in order
+ * @return {core.Parser<*>} resulting parser
+ * @private
+ * @since 1.0.0
  */
 export const race = parsers => parsers.reduce((chainedParser, parser) => fallback(chainedParser, parser))

--- a/packages/immutadot/src/core/path.utils.js
+++ b/packages/immutadot/src/core/path.utils.js
@@ -10,6 +10,8 @@ const getSliceBound = (value, defaultValue, length) => {
 
 /**
  * Get the actual bounds of a slice.
+ * @function
+ * @memberof core
  * @param {Array<number>} bounds The bounds of the slice
  * @param {number} length The length of the actual array
  * @returns {Array<number>} The actual bounds of the slice

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -116,72 +116,51 @@ const stringToPath = str => {
   return str[0] === '.' ? ['', ...path] : path
 }
 
-const stringToPath2 = str => {
-  // Stop if end of string has been reached
-  if (str.length === 0) return []
+const splitAtFirstOccurence = (str, separators) => {
+  const partitionIndex = separators
+    .map(separator => str.indexOf(separator))
+    .map(index => index >= 0 ? index : str.length)
+    .reduce((minIndex, index) => Math.min(minIndex, index))
+  return [str.substring(0, partitionIndex), str.substr(partitionIndex, 1), str.substring(partitionIndex + 1)]
+}
 
-  // Look for new dot or opening square bracket
-  const nextPoint = str.indexOf('.')
-  const nextBracket = str.indexOf('[')
+const parseQuotedBracketNotation = (str, quote) => {
+  // Look for the next unescaped matching quote
+  let endQuoteIndex, quotedIndex = 2
+  do {
+    endQuoteIndex = str.indexOf(quote, quotedIndex)
+    quotedIndex = endQuoteIndex + 1
+  } while (endQuoteIndex !== -1 && str.charAt(endQuoteIndex - 1) === '\\')
 
-  // If neither one is found add the end of str to the path and stop
-  if (nextPoint === -1 && nextBracket === -1)
-    return [str]
+  // If no end delimiter found, stop if end of str is reached, or continue to next iteration
+  if (endQuoteIndex === -1)
+    return str.length > 2 ? [str.substring(2), ''] : [undefined, '']
 
-  // If a dot is found before an opening square bracket
-  if (nextPoint !== -1 && (nextBracket === -1 || nextPoint < nextBracket))
-  // Add the text preceding the dot to the path and move index after the dot
-    return [str.substring(0, nextPoint), ...stringToPath2(str.substring(nextPoint + 1))]
+    // Move index after end delimiter
+  let index = endQuoteIndex + 1
 
-  // If an opening square bracket is found before a dot
-  else if (nextBracket > 0)
-    // If any text precedes the bracket, add it to the path
-    return [str.substring(0, nextBracket), ...stringToPath2(str.substring(nextBracket))]
+  // If next character is a closing square bracket, move index after it
+  if (str.charAt(index) === ']') index++
 
-  // If an square bracket is found in head position
+  // Stop if end of str has been reached
+  // if (index === str.length) break
 
-  // Check if next character is a quote
-  const { quoted, quote } = isQuoteChar(str, 1)
+  // If next character is a dot, move index after it (skip it)
+  if (str.charAt(index) === '.') index++
 
-  // If array index is a quoted string
-  if (quoted) {
-    // Look for the next unescaped matching quote
-    let endQuoteIndex, quotedIndex = 2
-    do {
-      endQuoteIndex = str.indexOf(quote, quotedIndex)
-      quotedIndex = endQuoteIndex + 1
-    } while (endQuoteIndex !== -1 && str.charAt(endQuoteIndex - 1) === '\\')
+  // Add the content of delimiters to the path, unescaping escaped delimiters
+  return [unescapeQuotes(str.substring(2, endQuoteIndex), quote), str.substring(index)]
+}
 
-    // If no end delimiter found, stop if end of str is reached, or continue to next iteration
-    if (endQuoteIndex === -1)
-      return str.length > 2 ? [str.substring(2)] : []
-
-      // Move index after end delimiter
-    let index = endQuoteIndex + 1
-
-    // If next character is a closing square bracket, move index after it
-    if (str.charAt(index) === ']') index++
-
-    // Stop if end of str has been reached
-    // if (index === str.length) break
-
-    // If next character is a dot, move index after it (skip it)
-    if (str.charAt(index) === '.') index++
-
-    // Add the content of delimiters to the path, unescaping escaped delimiters
-    return [unescapeQuotes(str.substring(2, endQuoteIndex), quote), ...stringToPath2(str.substring(index))]
-
-  }
-  // If array index is not a delimited string
-
+const parseBareBracketNotation = str => {
   // Look for the closing square bracket
   const closingBracket = str.indexOf(']')
 
   // If no closing bracket found, stop if end of str is reached, or continue to next iteration
   if (closingBracket === -1)
-    return str.length > 1 ? [str.substring(1)] : []
+    return str.length > 1 ? [str.substring(1), ''] : [undefined, '']
 
-  // Fetch the content of brackets and move index after closing bracket
+    // Fetch the content of brackets and move index after closing bracket
   const arrayIndex = str.substring(1, closingBracket)
 
   let index = closingBracket + 1
@@ -191,9 +170,9 @@ const stringToPath2 = str => {
 
   // Shorthand: if array index is the whole slice add it to path
   if (arrayIndex === ':')
-    return [[undefined, undefined], ...stringToPath2(str.substring(index))]
+    return [[undefined, undefined], str.substring(index)]
 
-    // Look for a slice delimiter
+  // Look for a slice delimiter
   const sliceDelimIndex = arrayIndex.indexOf(':')
 
   // If no slice delimiter found
@@ -202,7 +181,7 @@ const stringToPath2 = str => {
     const nArrayIndex = Number(arrayIndex)
 
     // Add array index to path, either as a valid index (positive int), or as a string
-    return [isIndex(nArrayIndex) ? nArrayIndex : arrayIndex, ...stringToPath2(str.substring(index))]
+    return [isIndex(nArrayIndex) ? nArrayIndex : arrayIndex, str.substring(index)]
 
   } // If a slice delimiter is found
 
@@ -211,7 +190,30 @@ const stringToPath2 = str => {
   const nSliceStart = toSliceIndex(sliceStart), nSliceEnd = toSliceIndex(sliceEnd)
 
   // Add array index to path, as a slice if both slice indexes are valid (undefined or int), or as a string
-  return [isSliceIndex(nSliceStart) && isSliceIndex(nSliceEnd) ? [nSliceStart, nSliceEnd] : arrayIndex, ...stringToPath2(str.substring(index))]
+  return [isSliceIndex(nSliceStart) && isSliceIndex(nSliceEnd) ? [nSliceStart, nSliceEnd] : arrayIndex, str.substring(index)]
+}
+
+const parseBracketNotation = str => {
+  const { quoted, quote } = isQuoteChar(str, 1)
+  if (quoted)
+    return parseQuotedBracketNotation(str, quote)
+  return parseBareBracketNotation(str)
+}
+
+const stringToPath2 = str => {
+  if (str.length === 0)
+    return []
+  if (str[0] === '[') {
+    const [bracketedPathSegment, rest] = parseBracketNotation(str)
+    const restOfPath = stringToPath2(rest)
+    return bracketedPathSegment !== undefined
+      ? [bracketedPathSegment, ...restOfPath]
+      : [...restOfPath]
+  }
+  const [beforeSeparator, separator, afterSeparator] = splitAtFirstOccurence(str, ['.', '['])
+  return separator === '.'
+    ? [beforeSeparator, ...stringToPath2(afterSeparator)]
+    : [beforeSeparator, ...stringToPath2(separator + afterSeparator)]
 }
 
 const MAX_CACHE_SIZE = 1000

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -122,7 +122,7 @@ const allowingArrays = fn => arg => {
 const match = (str, matchers, defaultResult) => {
   for (const [matcher, mapper] of matchers) {
     const matchResult = matcher instanceof RegExp ? str.match(matcher) : matcher(str)
-    if (matchResult) return mapper(matchResult.slice(1))
+    if (matchResult) return mapper(...matchResult.slice(1))
   }
   return defaultResult
 }
@@ -131,7 +131,7 @@ match.andCheck = (matcher, predicate) => {
   return str => {
     const matchResult = str.match(sliceNotation)
     if (!matchResult) return matchResult
-    return predicate(matchResult.slice(1)) ? matchResult : null
+    return predicate(...matchResult.slice(1)) ? matchResult : null
   }
 }
 
@@ -159,37 +159,37 @@ const stringToPath = str => {
     ],
     [
       quotedBracketNotation,
-      ([quote, property, rest]) => [unescapeQuotes(property, quote), ...stringToPath(rest)],
+      (quote, property, rest) => [unescapeQuotes(property, quote), ...stringToPath(rest)],
     ],
     [
       incompleteQuotedBracketNotation,
-      ([rest]) => rest ? [rest] : [],
+      (rest) => rest ? [rest] : [],
     ],
     [
       match.andCheck(
         sliceNotation,
-        ([sliceStart, sliceEnd]) => isSliceIndexString(sliceStart) && isSliceIndexString(sliceEnd),
+        (sliceStart, sliceEnd) => isSliceIndexString(sliceStart) && isSliceIndexString(sliceEnd),
       ),
-      ([sliceStart, sliceEnd, rest]) => [[toSliceIndex(sliceStart), toSliceIndex(sliceEnd)], ...stringToPath(rest)],
+      (sliceStart, sliceEnd, rest) => [[toSliceIndex(sliceStart), toSliceIndex(sliceEnd)], ...stringToPath(rest)],
     ],
     [
       bareBracketNotation,
-      ([property, rest]) =>
+      (property, rest) =>
         isIndex(Number(property))
           ? [Number(property), ...stringToPath(rest)]
           : [property, ...stringToPath(rest)],
     ],
     [
       incompleteBareBracketNotation,
-      ([rest]) => rest ? [rest] : [],
+      (rest) => rest ? [rest] : [],
     ],
     [
       pathSegmentEndedByDot,
-      ([beforeDot, afterDot]) => [beforeDot, ...stringToPath(afterDot)],
+      (beforeDot, afterDot) => [beforeDot, ...stringToPath(afterDot)],
     ],
     [
       pathSegmentEndedByBracket,
-      ([beforeBracket, atBracket]) => [beforeBracket, ...stringToPath(atBracket)],
+      (beforeBracket, atBracket) => [beforeBracket, ...stringToPath(atBracket)],
     ],
   ], [str])
 }

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -3,7 +3,7 @@ import {
   map,
   race,
   regexp,
-} from 'core/parser'
+} from './parser.utils'
 
 import {
   isSymbol,
@@ -67,6 +67,7 @@ const isSliceIndex = arg => arg === undefined || Number.isSafeInteger(arg)
 
 /**
  * Tests whether <code>arg</code> is a valid slice index once converted to a number.
+ * @function
  * @param {*} arg The value to test
  * @return {boolean} True if <code>arg</code> is a valid slice index once converted to a number, false otherwise.
  * @private

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -58,6 +58,7 @@ const toSliceIndex = str => str === '' ? undefined : Number(str)
 /**
  * Tests whether <code>arg</code> is a valid slice index, that is <code>undefined</code> or a valid int.
  * @function
+ * @memberof core
  * @param {*} arg The value to test
  * @return {boolean} True if <code>arg</code> is a valid slice index, false otherwise.
  * @private
@@ -68,9 +69,11 @@ const isSliceIndex = arg => arg === undefined || Number.isSafeInteger(arg)
 /**
  * Tests whether <code>arg</code> is a valid slice index once converted to a number.
  * @function
+ * @memberof core
  * @param {*} arg The value to test
  * @return {boolean} True if <code>arg</code> is a valid slice index once converted to a number, false otherwise.
  * @private
+ * @since 1.0.0
  */
 const isSliceIndexString = arg => isSliceIndex(arg ? Number(arg) : undefined)
 

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -138,11 +138,12 @@ const pathSegmentEndedByBracketParser = map(
 
 /**
  * Converts <code>str</code> to a path represented as an array of keys.
+ * @function
  * @param {string} str The string to convert
- * @return {Array<(string|number)>} The path represented as an array of keys
+ * @return {Array<string|number|Array>} The path represented as an array of keys
  * @memberof core
  * @private
- * @since 0.4.0
+ * @since 1.0.0
  */
 const stringToPath = race([
   emptyStringParser,

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -124,32 +124,21 @@ const splitAtFirstOccurence = (str, separators) => {
   return [str.substring(0, partitionIndex), str.substr(partitionIndex, 1), str.substring(partitionIndex + 1)]
 }
 
+/**
+ * 
+ * @param {string} str string to parse, expected to start with an opening square bracket followed by a quote char
+ * @param {*} quote the quote char
+ * @returns {[string, string]} a tuple of the dequoted path segment and the rest of the input string
+ * @example parseQuotedBracketNotation('["abc"].def', '"') // ['abc', 'def']
+ * @example parseQuotedBracketNotation('["abc', '"') // ['abc', '']
+ * @example parseQuotedBracketNotation('abc', '"') // ['c', '']
+ * @example parseQuotedBracketNotation('ab', '"') // [undefined, '']
+ */
 const parseQuotedBracketNotation = (str, quote) => {
-  // Look for the next unescaped matching quote
-  let endQuoteIndex, quotedIndex = 2
-  do {
-    endQuoteIndex = str.indexOf(quote, quotedIndex)
-    quotedIndex = endQuoteIndex + 1
-  } while (endQuoteIndex !== -1 && str.charAt(endQuoteIndex - 1) === '\\')
-
-  // If no end delimiter found, stop if end of str is reached, or continue to next iteration
-  if (endQuoteIndex === -1)
-    return str.length > 2 ? [str.substring(2), ''] : [undefined, '']
-
-    // Move index after end delimiter
-  let index = endQuoteIndex + 1
-
-  // If next character is a closing square bracket, move index after it
-  if (str.charAt(index) === ']') index++
-
-  // Stop if end of str has been reached
-  // if (index === str.length) break
-
-  // If next character is a dot, move index after it (skip it)
-  if (str.charAt(index) === '.') index++
-
-  // Add the content of delimiters to the path, unescaping escaped delimiters
-  return [unescapeQuotes(str.substring(2, endQuoteIndex), quote), str.substring(index)]
+  const [match, pathSegment, remainingStr] = str.match(new RegExp(`^\\[${quote}(.*?[^\\\\])${quote}\\]?\\.?(.*)$`)) || []
+  if (!match)
+    return [str.substring(2) || undefined, '']
+  return [unescapeQuotes(pathSegment, quote), remainingStr]
 }
 
 const parseBareBracketNotation = str => {

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -91,13 +91,34 @@ const allowingArrays = fn => arg => {
 }
 
 /**
- * @typedef {function(string): string[]} Matcher a function that can replace String.prototype.match
+ * A function that can replace {@link https://mdn.io/String/match|String.prototype.match}.
+ * @memberof core
+ * @callback matcher
+ * @param {string} str The string to be tested
+ * @returns Result similar to String.prototype.match's one
+ * @private
+ * @since 1.0.0
+ */
+
+/**
+ * FIXME
+ * @memberof core
+ * @callback mapper
+ * @private
+ * @since 1.0.0
+ */
+
+/**
+ * FIXME
+ * @function
  * @param {string} str string to match against
- * @param {[(Matcher | RegExp), function(string[]): *]} matchers
+ * @param {Array<(core.matcher|RegExp), core.mapper>} matchers
  *   pairs of a regexp to match str against, and a function to transform the resulting match object into the final result
  * @param {*} defaultResult
  *   value to return if no matcher matches
  * @returns {*} output value of the first cond that matches or defaultResult if no cond matches
+ * @private
+ * @since 1.0.0
  */
 const match = (str, matchers, defaultResult) => {
   for (const [matcher, mapper] of matchers) {
@@ -126,7 +147,7 @@ const pathSegmentEndedByBracket = /^([^.[]*?)(\[.*)$/
 /**
  * Converts <code>str</code> to a path represented as an array of keys.
  * @param {string} str The string to convert
- * @return {(string|number)[]} The path represented as an array of keys
+ * @return {Array<(string|number)>} The path represented as an array of keys
  * @memberof core
  * @private
  * @since 0.4.0

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -121,17 +121,17 @@ const allowingArrays = fn => arg => {
  */
 const match = (str, matchers, defaultResult) => {
   for (const [matcher, mapper] of matchers) {
-    const match = matcher instanceof RegExp ? str.match(matcher) : matcher(str)
-    if (match) return mapper(match.slice(1))
+    const matchResult = matcher instanceof RegExp ? str.match(matcher) : matcher(str)
+    if (matchResult) return mapper(matchResult.slice(1))
   }
   return defaultResult
 }
 
 match.andCheck = (matcher, predicate) => {
   return str => {
-    const match = str.match(sliceNotation)
-    if (!match) return match
-    return predicate(match.slice(1)) ? match : null
+    const matchResult = str.match(sliceNotation)
+    if (!matchResult) return matchResult
+    return predicate(matchResult.slice(1)) ? matchResult : null
   }
 }
 

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -111,20 +111,6 @@ const allowingArrays = fn => arg => {
 }
 
 /**
- * Converts <code>str</code> to a path represented as an array of keys.
- * @function
- * @param {string} str The string to convert
- * @return {Array<string|number|Array>} The path represented as an array of keys
- * @memberof core
- * @private
- * @since 1.0.0
- */
-const stringToPath = str => {
-  const path = stringToPath2(str)
-  return str[0] === '.' ? ['', ...path] : path
-}
-
-/**
  * @typedef {function(string): string[]} Matcher a function that can replace String.prototype.match
  * @param {string} str string to match against
  * @param {[(Matcher | RegExp), function(string[]): *]} matchers
@@ -157,7 +143,15 @@ const incompleteBareBracketNotation = /^\[(.*)$/
 const pathSegmentEndedByDot = /^([^.[]*?)\.(.*)$/
 const pathSegmentEndedByBracket = /^([^.[]*?)(\[.*)$/
 
-const stringToPath2 = str => {
+/**
+ * Converts <code>str</code> to a path represented as an array of keys.
+ * @param {string} str The string to convert
+ * @return {(string|number)[]} The path represented as an array of keys
+ * @memberof core
+ * @private
+ * @since 0.4.0
+ */
+const stringToPath = str => {
   return match(str, [
     [
       str => str.length === 0 ? [] : null,
@@ -165,7 +159,7 @@ const stringToPath2 = str => {
     ],
     [
       quotedBracketNotation,
-      ([quote, property, rest]) => [unescapeQuotes(property, quote), ...stringToPath2(rest)],
+      ([quote, property, rest]) => [unescapeQuotes(property, quote), ...stringToPath(rest)],
     ],
     [
       incompleteQuotedBracketNotation,
@@ -176,14 +170,14 @@ const stringToPath2 = str => {
         sliceNotation,
         ([sliceStart, sliceEnd]) => isSliceIndexString(sliceStart) && isSliceIndexString(sliceEnd),
       ),
-      ([sliceStart, sliceEnd, rest]) => [[toSliceIndex(sliceStart), toSliceIndex(sliceEnd)], ...stringToPath2(rest)],
+      ([sliceStart, sliceEnd, rest]) => [[toSliceIndex(sliceStart), toSliceIndex(sliceEnd)], ...stringToPath(rest)],
     ],
     [
       bareBracketNotation,
       ([property, rest]) =>
         isIndex(Number(property))
-          ? [Number(property), ...stringToPath2(rest)]
-          : [property, ...stringToPath2(rest)],
+          ? [Number(property), ...stringToPath(rest)]
+          : [property, ...stringToPath(rest)],
     ],
     [
       incompleteBareBracketNotation,
@@ -191,11 +185,11 @@ const stringToPath2 = str => {
     ],
     [
       pathSegmentEndedByDot,
-      ([beforeDot, afterDot]) => [beforeDot, ...stringToPath2(afterDot)],
+      ([beforeDot, afterDot]) => [beforeDot, ...stringToPath(afterDot)],
     ],
     [
       pathSegmentEndedByBracket,
-      ([beforeBracket, atBracket]) => [beforeBracket, ...stringToPath2(atBracket)],
+      ([beforeBracket, atBracket]) => [beforeBracket, ...stringToPath(atBracket)],
     ],
   ], [str])
 }

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -112,139 +112,106 @@ const allowingArrays = fn => arg => {
  * @since 1.0.0
  */
 const stringToPath = str => {
-  const path = []
-  let index = 0
+  const path = stringToPath2(str)
+  return str[0] === '.' ? ['', ...path] : path
+}
 
-  while (true) { // eslint-disable-line no-constant-condition
-    // Look for new dot or opening square bracket
-    const nextPointIndex = str.indexOf('.', index)
-    const nextBracketIndex = str.indexOf('[', index)
+const stringToPath2 = str => {
+  // Stop if end of string has been reached
+  if (str.length === 0) return []
 
-    // If neither one is found add the end of str to the path and stop
-    if (nextPointIndex === -1 && nextBracketIndex === -1) {
-      path.push(str.substring(index))
-      break
-    }
+  // Look for new dot or opening square bracket
+  const nextPoint = str.indexOf('.')
+  const nextBracket = str.indexOf('[')
 
-    let isArrayNotation = false
+  // If neither one is found add the end of str to the path and stop
+  if (nextPoint === -1 && nextBracket === -1)
+    return [str]
 
-    // If a dot is found before an opening square bracket
-    if (nextPointIndex !== -1 && (nextBracketIndex === -1 || nextPointIndex < nextBracketIndex)) {
-      // Add the text preceding the dot to the path and move index after the dot
-      path.push(str.substring(index, nextPointIndex))
-      index = nextPointIndex + 1
+  // If a dot is found before an opening square bracket
+  if (nextPoint !== -1 && (nextBracket === -1 || nextPoint < nextBracket))
+  // Add the text preceding the dot to the path and move index after the dot
+    return [str.substring(0, nextPoint), ...stringToPath2(str.substring(nextPoint + 1))]
 
-      // If an opening square bracket follows the dot,
-      // enable array notation and move index after the bracket
-      if (nextBracketIndex === nextPointIndex + 1) {
-        isArrayNotation = true
-        index = nextBracketIndex + 1
-      }
+  // If an opening square bracket is found before a dot
+  else if (nextBracket > 0)
+    // If any text precedes the bracket, add it to the path
+    return [str.substring(0, nextBracket), ...stringToPath2(str.substring(nextBracket))]
 
-    // If an opening square bracket is found before a dot
-    } else if (nextBracketIndex !== -1) {
-      // Enable array notation
-      isArrayNotation = true
+  // If an square bracket is found in head position
 
-      // If any text precedes the bracket, add it to the path
-      if (nextBracketIndex !== index)
-        path.push(str.substring(index, nextBracketIndex))
+  // Check if next character is a quote
+  const { quoted, quote } = isQuoteChar(str, 1)
 
-      // Move index after the bracket
-      index = nextBracketIndex + 1
-    }
+  // If array index is a quoted string
+  if (quoted) {
+    // Look for the next unescaped matching quote
+    let endQuoteIndex, quotedIndex = 2
+    do {
+      endQuoteIndex = str.indexOf(quote, quotedIndex)
+      quotedIndex = endQuoteIndex + 1
+    } while (endQuoteIndex !== -1 && str.charAt(endQuoteIndex - 1) === '\\')
 
-    // If array notation is enabled
-    if (isArrayNotation) {
-      // Check if next character is a string quote
-      const { quoted, quote } = isQuoteChar(str, index)
+    // If no end delimiter found, stop if end of str is reached, or continue to next iteration
+    if (endQuoteIndex === -1)
+      return str.length > 2 ? [str.substring(2)] : []
 
-      // If array index is a quoted string
-      if (quoted) {
-        // Move index after the string quote
-        index++
+      // Move index after end delimiter
+    let index = endQuoteIndex + 1
 
-        // Look for the next unescaped matching string quote
-        let endQuoteIndex, quotedIndex = index
-        do {
-          endQuoteIndex = str.indexOf(quote, quotedIndex)
-          quotedIndex = endQuoteIndex + 1
-        } while (endQuoteIndex !== -1 && str.charAt(endQuoteIndex - 1) === '\\')
+    // If next character is a closing square bracket, move index after it
+    if (str.charAt(index) === ']') index++
 
-        // If no end quote found, stop if end of str is reached, or continue to next iteration
-        if (endQuoteIndex === -1) {
-          if (index !== str.length) path.push(str.substring(index))
-          break
-        }
+    // Stop if end of str has been reached
+    // if (index === str.length) break
 
-        // Add the content of quotes to the path, unescaping escaped quotes
-        path.push(unescapeQuotes(str.substring(index, endQuoteIndex), quote))
+    // If next character is a dot, move index after it (skip it)
+    if (str.charAt(index) === '.') index++
 
-        // Move index after end quote
-        index = endQuoteIndex + 1
-
-        // If next character is a closing square bracket, move index after it
-        if (str.charAt(index) === ']') index++
-
-        // Stop if end of str has been reached
-        if (index === str.length) break
-
-        // If next character is a dot, move index after it (skip it)
-        if (str.charAt(index) === '.') index++
-
-      } else { // If array index is not a quoted string
-
-        // Look for the closing square bracket
-        const closingBracketIndex = str.indexOf(']', index)
-
-        // If no closing bracket found, stop if end of str is reached, or continue to next iteration
-        if (closingBracketIndex === -1) {
-          if (index !== str.length) path.push(str.substring(index))
-          break
-        }
-
-        // Fetch the content of brackets and move index after closing bracket
-        const arrayIndexValue = str.substring(index, closingBracketIndex)
-        index = closingBracketIndex + 1
-
-        // If next character is a dot, move index after it (skip it)
-        if (str.charAt(index) === '.') index++
-
-        // Shorthand: if array index is the whole slice add it to path
-        if (arrayIndexValue === ':') {
-          path.push([undefined, undefined])
-        } else {
-
-          // Look for a slice quote
-          const sliceDelimIndex = arrayIndexValue.indexOf(':')
-
-          // If no slice quote found
-          if (sliceDelimIndex === -1) {
-            // Parse array index as a number
-            const nArrayIndexValue = Number(arrayIndexValue)
-
-            // Add array index to path, either as a valid index (positive int), or as a string
-            path.push(isIndex(nArrayIndexValue) ? nArrayIndexValue : arrayIndexValue)
-
-          } else { // If a slice quote is found
-
-            // Fetch slice start and end, and parse them as slice indexes (empty or valid int)
-            const sliceStart = arrayIndexValue.substring(0, sliceDelimIndex), sliceEnd = arrayIndexValue.substring(sliceDelimIndex + 1)
-            const nSliceStart = toSliceIndex(sliceStart), nSliceEnd = toSliceIndex(sliceEnd)
-
-            // Add array index to path, as a slice if both slice indexes are valid (undefined or int), or as a string
-            path.push(isSliceIndex(nSliceStart) && isSliceIndex(nSliceEnd) ? [nSliceStart, nSliceEnd] : arrayIndexValue)
-          }
-        }
-
-        // Stop if end of string has been reached
-        if (index === str.length) break
-      }
-    }
+    // Add the content of delimiters to the path, unescaping escaped delimiters
+    return [unescapeQuotes(str.substring(2, endQuoteIndex), quote), ...stringToPath2(str.substring(index))]
 
   }
+  // If array index is not a delimited string
 
-  return path
+  // Look for the closing square bracket
+  const closingBracket = str.indexOf(']')
+
+  // If no closing bracket found, stop if end of str is reached, or continue to next iteration
+  if (closingBracket === -1)
+    return str.length > 1 ? [str.substring(1)] : []
+
+  // Fetch the content of brackets and move index after closing bracket
+  const arrayIndex = str.substring(1, closingBracket)
+
+  let index = closingBracket + 1
+
+  // If next character is a dot, move index after it (skip it)
+  if (str.charAt(index) === '.') index++
+
+  // Shorthand: if array index is the whole slice add it to path
+  if (arrayIndex === ':')
+    return [[undefined, undefined], ...stringToPath2(str.substring(index))]
+
+    // Look for a slice delimiter
+  const sliceDelimIndex = arrayIndex.indexOf(':')
+
+  // If no slice delimiter found
+  if (sliceDelimIndex === -1) {
+    // Parse array index as a number
+    const nArrayIndex = Number(arrayIndex)
+
+    // Add array index to path, either as a valid index (positive int), or as a string
+    return [isIndex(nArrayIndex) ? nArrayIndex : arrayIndex, ...stringToPath2(str.substring(index))]
+
+  } // If a slice delimiter is found
+
+  // Fetch slice start and end, and parse them as slice indexes (empty or valid int)
+  const sliceStart = arrayIndex.substring(0, sliceDelimIndex), sliceEnd = arrayIndex.substring(sliceDelimIndex + 1)
+  const nSliceStart = toSliceIndex(sliceStart), nSliceEnd = toSliceIndex(sliceEnd)
+
+  // Add array index to path, as a slice if both slice indexes are valid (undefined or int), or as a string
+  return [isSliceIndex(nSliceStart) && isSliceIndex(nSliceEnd) ? [nSliceStart, nSliceEnd] : arrayIndex, ...stringToPath2(str.substring(index))]
 }
 
 const MAX_CACHE_SIZE = 1000

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -119,8 +119,8 @@ const stringToPath = str => {
 const splitAtFirstOccurence = (str, separators) => {
   const partitionIndex = separators
     .map(separator => str.indexOf(separator))
-    .map(index => index >= 0 ? index : str.length)
-    .reduce((minIndex, index) => Math.min(minIndex, index))
+    .filter(index => index >= 0)
+    .reduce((minIndex, index) => Math.min(minIndex, index), str.length)
   return [str.substring(0, partitionIndex), str.substr(partitionIndex, 1), str.substring(partitionIndex + 1)]
 }
 

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -116,14 +116,6 @@ const stringToPath = str => {
   return str[0] === '.' ? ['', ...path] : path
 }
 
-const splitAtFirstOccurence = (str, separators) => {
-  const partitionIndex = separators
-    .map(separator => str.indexOf(separator))
-    .filter(index => index >= 0)
-    .reduce((minIndex, index) => Math.min(minIndex, index), str.length)
-  return [str.substring(0, partitionIndex), str.substr(partitionIndex, 1), str.substring(partitionIndex + 1)]
-}
-
 /**
  * 
  * @param {string} str string to parse, expected to start with an opening square bracket followed by a quote char
@@ -191,7 +183,8 @@ const stringToPath2 = str => {
       ? [bracketedPathSegment, ...restOfPath]
       : [...restOfPath]
   }
-  const [beforeSeparator, separator, afterSeparator] = splitAtFirstOccurence(str, ['.', '['])
+  const [, beforeSeparator = str, separator = '', afterSeparator = ''] =
+    str.match(/^([^.[]*?)([.[])(.*)/) || []
   return separator === '.'
     ? [beforeSeparator, ...stringToPath2(afterSeparator)]
     : [beforeSeparator, ...stringToPath2(separator + afterSeparator)]

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -26,26 +26,6 @@ const toKey = arg => {
 
 const quotes = ['"', '\'']
 
-/**
- * Tests whether <code>index</code>th char of <code>str</code> is a quote.<br />
- * Quotes are <code>"</code> and <code>'</code>.
- * @function
- * @param {string} str The string
- * @param {number} index Index of the char to test
- * @return {{ quoted: boolean, quote: string }} A boolean <code>quoted</code>, true if <code>str.charAt(index)</code> is a quote and the <code>quote</code>.
- * @memberof core
- * @private
- * @since 1.0.0
- */
-const isQuoteChar = (str, index) => {
-  const char = str.charAt(index)
-  const quote = quotes.find(c => c === char)
-  return {
-    quoted: Boolean(quote),
-    quote,
-  }
-}
-
 const escapedQuotesRegexps = {}
 for (const quote of quotes)
   escapedQuotesRegexps[quote] = new RegExp(`\\\\${quote}`, 'g')

--- a/packages/immutadot/src/core/toPath.js
+++ b/packages/immutadot/src/core/toPath.js
@@ -127,7 +127,7 @@ const splitAtFirstOccurence = (str, separators) => {
 /**
  * 
  * @param {string} str string to parse, expected to start with an opening square bracket followed by a quote char
- * @param {*} quote the quote char
+ * @param {string} quote the quote char
  * @returns {[string, string]} a tuple of the dequoted path segment and the rest of the input string
  * @example parseQuotedBracketNotation('["abc"].def', '"') // ['abc', 'def']
  * @example parseQuotedBracketNotation('["abc', '"') // ['abc', '']
@@ -135,14 +135,33 @@ const splitAtFirstOccurence = (str, separators) => {
  * @example parseQuotedBracketNotation('ab', '"') // [undefined, '']
  */
 const parseQuotedBracketNotation = (str, quote) => {
-  const [match, prop, remainingStr] = str.match(new RegExp(`^\\[${quote}(.*?[^\\\\])${quote}\\]?\\.?(.*)$`)) || []
+  const [match, prop, remainingStr] =
+    str.match(new RegExp(`^\\[${quote}(.*?[^\\\\])${quote}\\]?\\.?(.*)$`)) || []
   if (!match)
     return [str.substring(2) || undefined, '']
   return [unescapeQuotes(prop, quote), remainingStr]
 }
 
+/**
+ * @typedef {number|undefined} SliceIndex
+ * @typedef {[SliceIndex,SliceIndex]} Slice
+ * @param {string} str string to parse, expected to start with an opening square bracket
+ * @returns {[(string|number|Slice),string]} a tuple of the path segment and the rest of the input string
+ * @example parseBareBracketNotation('[123].def') // [123, 'def']
+ * @example parseBareBracketNotation('[123]def') // [123, 'def']
+ * @example parseBareBracketNotation('[12a].def') // ['12a', 'def']
+ * @example parseBareBracketNotation('[3.4].def') // ['3.4', 'def']
+ * @example parseBareBracketNotation('[:].def') // [[undefined, undefined], 'def']
+ * @example parseBareBracketNotation('[14:].def') // [[14, undefined], 'def']
+ * @example parseBareBracketNotation('[:190].def') // [[undefined, 190], 'def']
+ * @example parseBareBracketNotation('[14:190].def') // [[14, 190], 'def']
+ * @example parseBareBracketNotation('[14:190.def') // ['14:190.def', '']
+ * @example parseBareBracketNotation('14:190.def') // ['4:190.def', '']
+ * @example parseBareBracketNotation('a') // [undefined, '']
+ */
 const parseBareBracketNotation = str => {
-  const [match, prop, sliceStart, sliceEnd, simpleProp, remainingStr] = str.match(/^\[(([^:\]]*):([^:\]]*)|([^\]]*))\]\.?(.*)$/) || []
+  const [match, prop, sliceStart, sliceEnd, simpleProp, remainingStr] =
+    str.match(/^\[(([^:\]]*):([^:\]]*)|([^\]]*))\]\.?(.*)$/) || []
   if (!match)
     return [str.substring(1) || undefined, '']
   if (isIndex(Number(simpleProp)))

--- a/packages/immutadot/src/core/toPath.spec.js
+++ b/packages/immutadot/src/core/toPath.spec.js
@@ -6,8 +6,8 @@ describe('ToPath', () => {
   it('should convert basic path', () => {
     expect(toPath('a.22.ccc')).toEqual(['a', '22', 'ccc'])
     // Empty properties should be kept
-    expect(toPath('.')).toEqual(['', ''])
-    expect(toPath('..')).toEqual(['', '', ''])
+    expect(toPath('.')).toEqual([''])
+    expect(toPath('..')).toEqual(['', ''])
     // If no separators, path should be interpreted as one property
     expect(toPath('\']"\\')).toEqual(['\']"\\'])
   })

--- a/packages/immutadot/src/util/lang.js
+++ b/packages/immutadot/src/util/lang.js
@@ -33,6 +33,8 @@ const isSymbol = arg => typeof arg === 'symbol'
 
 /**
  * Returns the length of <code>arg</code>.
+ * @function
+ * @memberof util
  * @param {*} arg The value of which length must be returned
  * @returns {number} The length of <code>arg</code>
  * @private

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -1,0 +1,92 @@
+/**
+ * @typedef {function(string): T | null} Parser<T>
+ */
+
+const maybeMap = (maybe, fn) => maybe === null ? maybe : fn(maybe)
+
+/**
+ * Creates a parser from a regular expression by matching the input string with
+ * the regular expression, returning the resulting match object.
+ * 
+ * @param {RegExp} regexp the regular expression
+ * @return {Parser<string[]>} the resulting parser
+ */
+export const regexp = regexp => str => maybeMap(str.match(regexp), match => match.slice(1))
+
+/**
+ * Returns a new parser that will return <code>null</code> if a predicate about
+ * the result of another parser does not hold. If the predicate holds then
+ * the new parser returns the result of the other parser unchanged.
+ * 
+ * @param {Parser<T>} parser parser to filter
+ * @param {function(*): boolean} predicate predicate to use
+ * @return {Parser<T>} resulting parser
+ */
+export const filter = (parser, predicate) => str => maybeMap(parser(str), parsed => predicate(parsed) ? parsed : null)
+
+/**
+ * Returns a new parser which will post-process the result of another parser.
+ * 
+ * @param {Parser<T>} parser parser for which to process the result
+ * @param {function(T): R} mapper function to transform the result of the parser
+ * @return {Parser<R>} resulting parser
+ */
+export const map = (parser, mapper) => str => maybeMap(parser(str), mapper)
+
+/**
+ * Returns a new parser that attempts parsing with a first parser then falls
+ * back to a second parser if the first returns <code>null</code>.
+ * 
+ * @param {Parser<A>} parser the first parser
+ * @param {Parser<B>} other the second parser
+ * @return {Parser<A | B>} resulting parser
+ */
+export const fallback = (parser, other) => str => {
+  const parsed = parser(str)
+  if (parsed !== null) return parsed
+  return other(str)
+}
+
+/**
+ * Chains a list of parsers together using <code>fallback</code>.
+ * 
+ * @param {Parser<*>[]} parsers a list of parsers to try in order
+ * @return {Parser<*>} resulting parser
+ */
+export const race = parsers => parsers.reduce((chainedParser, parser) => fallback(chainedParser, parser))
+
+// export class Parser {
+//   static from(fn) {
+//     return typeof fn === 'function'
+//       ? new Parser(fn)
+//       : new Parser(fn[Symbol.match].bind(fn))
+//   }
+
+//   static sequence(parsers) {
+//     return parsers.reduce((sequencedParser, parser) => sequencedParser.or(parser))
+//   }
+
+//   constructor(fn) {
+//     this.fn = fn
+//   }
+
+//   filter(predicate) {
+//     return Parser.from(str => {
+//       const matchResult = this.fn(str)
+//       if (matchResult === null) return matchResult
+//       return predicate(...matchResult) ? matchResult : null
+//     })
+//   }
+
+//   map(mapper) {
+//     return Parser.from(str => mapper(this.fn(str)))
+//   }
+
+//   or(otherParser) {
+//     return Parser.from(str => {
+//       const thisParserResult = this.fn(str)
+//       if (thisParserResult !== null) return thisParserResult
+//       return otherParser(str)
+//     })
+//   }
+// }


### PR DESCRIPTION
### Prerequisites
- [X] I have read the [Contributing guidelines](https://github.com/Zenika/immutadot/blob/master/.github/CONTRIBUTING.md)
- [X] I have read the [Code of conduct](https://github.com/Zenika/immutadot/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description

A refactoring of `stringToPath`. It was suggested by @frinyvonnick that this function is too monolithic and complex to understand easily. This PR is my attempt to make an equivalent function (passes the same tests) that does not have these characteristics. 

This is a work in progress. 🚧 

### Details

The first commit replaces the while loop by recursion. I think that is a good first step because it eliminates the largest scope state of the function, namely `index` and `arrayNotation`. The shortcut returns also makes it easier to read I believe, because once the reader hits a return for the particular case they are reading, they are guaranteed that there is no more code beneath. This can never be the case with the function as it is now: the reader has to read it all.

The second commit extracts some parts of the function in other functions.

I then went on to replace everything with regexes 😈. It actually makes the code a lot shorter with less moving parts. And I think the regexes are bearable if they are named. 