### PR TITLE
⚡ Avoid unnecessary mutations in apply

### DIFF
--- a/misc/test.utils.js
+++ b/misc/test.utils.js
@@ -25,5 +25,6 @@ export const immutaTest = (cb, input, ...paths) => {
 
   expect(input).toBeDeep(inputRefs)
   expect(output).toBeDeep(inputRefs, { exclude: paths })
-  expect(output).not.toBeDeep(inputRefs, { include: paths })
+  if (paths.length !== 0)
+    expect(output).not.toBeDeep(inputRefs, { include: paths })
 }

--- a/packages/immutadot/src/core/apply.js
+++ b/packages/immutadot/src/core/apply.js
@@ -30,6 +30,11 @@ const copy = (value, asArray) => {
   return { ...value }
 }
 
+const getNewObj = (obj, prop, doCopy) => {
+  if (!doCopy) return obj
+  return copy(obj, isIndex(prop))
+}
+
 /**
  * Operation to apply on a nested property of an object, to be called by {@link core.apply|apply}.
  * @memberof core
@@ -72,29 +77,38 @@ const apply = operation => {
         const [start, end] = getSliceBounds(prop, length(curObj))
 
         const newArr = copy(curObj, true)
+        let noop = true
 
-        for (let i = start; i < end; i++)
-          walkPath(newArr, [i, ...pathRest], false)
+        for (let i = start; i < end; i++) {
+          const [iNoop] = walkPath(newArr, [i, ...pathRest], false)
+          noop = noop && iNoop
+        }
 
-        return newArr
+        if (noop) return [true, curObj]
+
+        return [false, newArr]
       }
 
       const value = isNil(curObj) ? undefined : curObj[prop]
 
-      let newObj = curObj
-      if (doCopy) newObj = copy(curObj, isIndex(prop))
-
       if (curPath.length === 1) {
+        const newObj = getNewObj(curObj, prop, doCopy)
         operation(newObj, prop, value, ...args)
-        return newObj
+        return [false, newObj]
       }
 
-      newObj[prop] = walkPath(value, pathRest)
+      const [noop, newValue] = walkPath(value, pathRest)
+      if (noop) return [true, curObj]
 
-      return newObj
+      const newObj = getNewObj(curObj, prop, doCopy)
+
+      newObj[prop] = newValue
+
+      return [false, newObj]
     }
 
-    return walkPath(obj, unsafeToPath(path))
+    const [, result] = walkPath(obj, unsafeToPath(path))
+    return result
   }
 
   const uncurried = (obj, path, ...args) => curried(path, ...args)(obj)

--- a/packages/immutadot/src/core/apply.js
+++ b/packages/immutadot/src/core/apply.js
@@ -30,9 +30,19 @@ const copy = (value, asArray) => {
   return { ...value }
 }
 
-const getNewObj = (obj, prop, doCopy) => {
-  if (!doCopy) return obj
-  return copy(obj, isIndex(prop))
+/**
+ * Makes a copy of <code>value</code> if necessary.
+ * @function
+ * @param {*} value The value to make a copy of
+ * @param {string} prop The accessed property in <code>value</code>
+ * @param {boolean} doCopy Whether to make a copy or not
+ * @returns {Object|Array} A copy of value, or not ;)
+ * @private
+ * @since 1.0.0
+ */
+const copyIfNecessary = (value, prop, doCopy) => {
+  if (!doCopy) return value
+  return copy(value, isIndex(prop))
 }
 
 /**
@@ -85,14 +95,13 @@ const apply = operation => {
         }
 
         if (noop) return [true, curObj]
-
         return [false, newArr]
       }
 
       const value = isNil(curObj) ? undefined : curObj[prop]
 
       if (curPath.length === 1) {
-        const newObj = getNewObj(curObj, prop, doCopy)
+        const newObj = copyIfNecessary(curObj, prop, doCopy)
         operation(newObj, prop, value, ...args)
         return [false, newObj]
       }
@@ -100,10 +109,8 @@ const apply = operation => {
       const [noop, newValue] = walkPath(value, pathRest)
       if (noop) return [true, curObj]
 
-      const newObj = getNewObj(curObj, prop, doCopy)
-
+      const newObj = copyIfNecessary(curObj, prop, doCopy)
       newObj[prop] = newValue
-
       return [false, newObj]
     }
 

--- a/packages/immutadot/src/core/apply.spec.js
+++ b/packages/immutadot/src/core/apply.spec.js
@@ -105,23 +105,57 @@ describe('Apply', () => {
       'nested.prop.1.val',
       'nested.prop.2.val',
     )
+
+    immutaTest(
+      input => {
+        const output = inc(input, 'nested.prop[3:5].val', 6)
+        expect(output).toEqual({
+          nested: { prop: [{ val: 0 }, { val: 1 }, undefined, { val: 6 }, { val: 6 }] },
+          other: {},
+        })
+        return output
+      },
+      {
+        nested: { prop: [{ val: 0 }, { val: 1 }] },
+        other: {},
+      },
+      'nested.prop.2',
+      'nested.prop.3.val',
+      'nested.prop.4.val',
+    )
   })
 
-  immutaTest(
-    input => {
-      const output = inc(input, 'nested.prop[3:5].val', 6)
-      expect(output).toEqual({
-        nested: { prop: [{ val: 0 }, { val: 1 }, undefined, { val: 6 }, { val: 6 }] },
+  it('should avoid unnecessary mutations', () => {
+    immutaTest(
+      input => inc(input, 'nested.prop[0:0].val', 6),
+      {
+        nested: { prop: [{ val: 0 }, { val: 1 }] },
         other: {},
-      })
-      return output
-    },
-    {
-      nested: { prop: [{ val: 0 }, { val: 1 }] },
-      other: {},
-    },
-    'nested.prop.2',
-    'nested.prop.3.val',
-    'nested.prop.4.val',
-  )
+      },
+    )
+
+    immutaTest(
+      input => inc(input, 'nested.prop[:].arr[0:0].val', 6),
+      {
+        nested: { prop: [{ arr: [{ val: 0 }, { val: 1 }] }, { arr: [{ val: 2 }] }] },
+        other: {},
+      },
+    )
+
+    immutaTest(
+      input => {
+        const output = inc(input, 'nested.prop[:].arr[1:].val', 6)
+        expect(output).toEqual({
+          nested: { prop: [{ arr: [{ val: 0 }, { val: 7 }] }, { arr: [{ val: 2 }] }] },
+          other: {},
+        })
+        return output
+      },
+      {
+        nested: { prop: [{ arr: [{ val: 0 }, { val: 1 }] }, { arr: [{ val: 2 }] }] },
+        other: {},
+      },
+      'nested.prop.0.arr.1.val',
+    )
+  })
 })


### PR DESCRIPTION
### Description
Avoid unnecessary mutations in `core.apply`.

**Issue :** fix #131

### Example usage
See new tests.