### PR TITLE
fix name conflicts between array.slice and string.slice

### DIFF
--- a/misc/generate-flow.js
+++ b/misc/generate-flow.js
@@ -108,6 +108,21 @@ ChainWrapper.prototype.${name} = function(path, ...args) {
 }
 `, /* eslint-enable */
           )
+
+          if (conflicts.includes(name)) {
+            await writeFile(
+              path.resolve(nsDir, `${name}.ns.js`),
+              /* eslint-disable indent */
+`import { ChainWrapper } from '${external ? 'immutadot/' : ''}seq/ChainWrapper'
+
+import { ${name} } from '${namespace}/${name}'
+
+ChainWrapper.prototype.${namespace}${_.capitalize(name)} = function(path, ...args) {
+  return this._call(${name}, path, args)
+}
+`, /* eslint-enable */
+            )
+          }
         }
       })()
 
@@ -117,12 +132,19 @@ ChainWrapper.prototype.${name} = function(path, ...args) {
 `${nsItems.map(({ name }) => `import './${name}'`).join('\n')}
 `, /* eslint-enable */
       )
+
+      await writeFile(
+        path.resolve(nsDir, 'ns.js'),
+        /* eslint-disable indent */
+`${nsItems.map(({ name }) => `import './${name}${conflicts.includes(name) ? '.ns' : ''}'`).join('\n')}
+`, /* eslint-enable */
+      )
     }))
 
     await writeFile(
       path.resolve(seqDir, 'all.js'),
       /* eslint-disable indent */
-      `${namespaces.map(namespace => `import './${namespace}'`).join('\n')}
+      `${namespaces.map(namespace => `import './${namespace}/ns'`).join('\n')}
 `, /* eslint-enable */
     )
   } catch (e) {

--- a/packages/immutadot/src/array/concat.js
+++ b/packages/immutadot/src/array/concat.js
@@ -1,7 +1,8 @@
 import { convertArrayMethod } from './convertArrayMethod'
 
 /**
- * Replaces an array concatenating the former array with additional arrays and/or values.
+ * Replaces an array concatenating the former array with additional arrays and/or values.<br/>
+ * ⚠ Due to name conflicts, this function is named <code>arrayConcat</code> when imported from top level (<code>import { arrayConcat } from 'immutadot'</code>).
  * @function
  * @memberof array
  * @param {Object} object The object to modify.

--- a/packages/immutadot/src/array/slice.js
+++ b/packages/immutadot/src/array/slice.js
@@ -1,7 +1,8 @@
 import { convertArrayMethod } from './convertArrayMethod'
 
 /**
- * Replaces an array by a slice of the former array from <code>start</code> up to, but not including, <code>end</code>.
+ * Replaces an array by a slice of the former array from <code>start</code> up to, but not including, <code>end</code>.<br/>
+ * ⚠ Due to name conflicts, this function is named <code>arraySlice</code> when imported from top level (<code>import { arraySlice } from 'immutadot'</code>).
  * @function
  * @memberof array
  * @param {Object} object The object to modify.

--- a/packages/immutadot/src/index.js
+++ b/packages/immutadot/src/index.js
@@ -1,7 +1,35 @@
-export * from './array'
+export {
+  concat as arrayConcat,
+  fill,
+  filter,
+  map,
+  pop,
+  push,
+  reverse,
+  shift,
+  slice as arraySlice,
+  sort,
+  splice,
+  unshift,
+} from './array'
 export * from './core'
 export * from './lang'
 export * from './object'
 export * from './seq'
-export * from './string'
+export {
+  concat as stringConcat,
+  padEnd,
+  padStart,
+  replace,
+  slice as stringSlice,
+  substr,
+  substring,
+  toLocaleLowerCase,
+  toLocaleUpperCase,
+  toLowerCase,
+  toUpperCase,
+  trim,
+  trimLeft,
+  trimRight,
+} from './string'
 export * from './util'

--- a/packages/immutadot/src/string/concat.js
+++ b/packages/immutadot/src/string/concat.js
@@ -1,7 +1,8 @@
 import { convertStringMethod } from './convertStringMethod'
 
 /**
- * Replaces by former string concatenated with <code>strings</code>.
+ * Replaces by former string concatenated with <code>strings</code>.<br/>
+ * ⚠ Due to name conflicts, this function is named <code>stringConcat</code> when imported from top level (<code>import { stringConcat } from 'immutadot'</code>).
  * @function
  * @memberof string
  * @param {Object} object The object to modify.

--- a/packages/immutadot/src/string/slice.js
+++ b/packages/immutadot/src/string/slice.js
@@ -1,7 +1,8 @@
 import { convertStringMethod } from './convertStringMethod'
 
 /**
- * Replaces by a slice of former string starting at <code>beginIndex</code> and ending at <code>endIndex</code> or end of the string.
+ * Replaces by a slice of former string starting at <code>beginIndex</code> and ending at <code>endIndex</code> or end of the string.<br/>
+ * ⚠ Due to name conflicts, this function is named <code>stringSlice</code> when imported from top level (<code>import { stringSlice } from 'immutadot'</code>).
  * @function
  * @memberof string
  * @param {Object} object The object to modify.


### PR DESCRIPTION
**Issue :** fix #190

Conflicted names are now aliased when using top level imports.

## Examples
### Classic operations
```js
import { arrayConcat, stringConcat } from 'immutadot'
// or
const { arrayConcat, stringConcat } = require('immutadot')
```

### chain operations
```js
import { chain } from 'immutadot'
import 'immutadot/seq/all'

chain(obj)
  .arrayConcat('a.b.c', [3, 4])
  .stringConcat('d.e.f', 'foo')
  .value()
```

### Flow operations
```js
import { flow, arrayConcat, stringConcat } from 'immutadot/flow'
```
