### PR TITLE
Simplify toPath

### DIFF
--- a/packages/immutadot/src/core/get.js
+++ b/packages/immutadot/src/core/get.js
@@ -3,7 +3,7 @@ import {
   prop,
 } from 'path/consts'
 import { isNil } from 'util/lang'
-import { unsafeToPath } from 'path/toPath'
+import { toPath } from 'path/toPath'
 
 /**
 * Gets the value at <code>path</code> of <code>obj</code>.
@@ -23,7 +23,7 @@ function get(obj, path, defaultValue) {
     const [[, prop], ...pathRest] = remPath
     return walkPath(curObj[prop], pathRest)
   }
-  const parsedPath = unsafeToPath(path)
+  const parsedPath = toPath(path)
   if (parsedPath.some(([propType]) => propType !== prop && propType !== index))
     throw TypeError('get supports only properties and array indexes in path')
   return walkPath(obj, parsedPath)

--- a/packages/immutadot/src/path/apply.js
+++ b/packages/immutadot/src/path/apply.js
@@ -17,7 +17,7 @@ import {
   length,
 } from 'util/lang'
 
-import { unsafeToPath } from './toPath'
+import { toPath } from './toPath'
 
 /**
  * Makes a copy of value.
@@ -88,7 +88,7 @@ const copyIfNecessary = (value, propType, doCopy) => {
  */
 const apply = operation => {
   const curried = (pPath, ...args) => {
-    const path = unsafeToPath(pPath)
+    const path = toPath(pPath)
 
     if (path.length === 0) throw new TypeError('path should not be empty')
 

--- a/packages/immutadot/src/path/index.js
+++ b/packages/immutadot/src/path/index.js
@@ -1,7 +1,0 @@
-/**
-* Path functions.
-* @namespace path
-* @since 1.0.0
-*/
-
-export { toPath } from './toPath'

--- a/packages/immutadot/src/path/toPath.spec.js
+++ b/packages/immutadot/src/path/toPath.spec.js
@@ -7,14 +7,18 @@ import {
   slice,
 } from './consts'
 
-import { toPath } from 'path'
+import { toPath } from './toPath'
 
 describe('path.toPath', () => {
 
   it('should convert basic path', () => {
     expect(toPath('a.22.ccc')).toEqual([[prop, 'a'], [prop, '22'], [prop, 'ccc']])
+    // Leading dot should be discarded
+    expect(toPath('.a')).toEqual([[prop, 'a']])
     // Empty properties should be kept
     expect(toPath('.')).toEqual([[prop, '']])
+    expect(toPath('..prop')).toEqual([[prop, ''], [prop, 'prop']])
+    expect(toPath('.a.')).toEqual([[prop, 'a'], [prop, '']])
     expect(toPath('..')).toEqual([[prop, ''], [prop, '']])
     // If no separators, path should be interpreted as one property
     expect(toPath('\']"\\')).toEqual([[prop, '\']"\\']])
@@ -62,24 +66,6 @@ describe('path.toPath', () => {
   it('should convert mixed path', () => {
     expect(toPath('a[0]["b.c"].666[1:].{1a,2b,3c}')).toEqual([[prop, 'a'], [index, 0], [prop, 'b.c'], [prop, '666'], [slice, [1, undefined]], [list, ['1a', '2b', '3c']]])
     expect(toPath('a.[0].["b.c"]666[1:2:3]{1a}{"2b",\'3c\'}')).toEqual([[prop, 'a'], [index, 0], [prop, 'b.c'], [prop, '666'], [prop, '1:2:3'], [prop, '1a'], [list, ['2b', '3c']]])
-  })
-
-  it('should not convert array path', () => {
-    expect(toPath([
-      [index, 666],
-      [prop, Symbol.for('🍺')],
-      [prop, 'test'],
-      [slice, [1, undefined]],
-      [slice, [0, -2]],
-      [list, ['1a', '2b', '3c']],
-    ])).toEqual([
-      [index, 666],
-      [prop, Symbol.for('🍺')],
-      [prop, 'test'],
-      [slice, [1, undefined]],
-      [slice, [0, -2]],
-      [list, ['1a', '2b', '3c']],
-    ])
   })
 
   it('should give empty path for nil values', () => {


### PR DESCRIPTION
 - Remove from public API
 - Remove possibility of giving an array (was used by chain and using...)
 - Memoize after toString conversion
 - Discard leading dot