### PR TITLE
Add qim to benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,30 +100,33 @@ If you were using a version of immutad●t previous to 1.0, check out the [migra
 
 A [simple benchmark](https://github.com/Zenika/immutadot/tree/master/packages/immutadot-benchmark/src/updateTodos.spec.js) (freely inspired from one made by [mweststrate](https://github.com/mweststrate) for [immer](https://github.com/mweststrate/immer)) reveals that immutad●t shows good results compared to other libraries.
 
-:warning: The following results should be taken with caution, they may vary depending on the hardware, the JavaScript engine, and the kind of operations performed. This particular test updates 10% out of a list of todos items, and was ran with Node 9.3.0 on an Intel® Core™ i7-6560U CPU @ 2.20GHz.
+:warning: The following results should be taken with caution, they may vary depending on the hardware, the JavaScript engine, and the kind of operations performed. This particular test updates 10% out of a list of todos items, and was ran with Node 9.8.0 on an Intel® Core™ i7-6560U CPU @ 2.20GHz.
 
 ```
 Update small todos list (1000 items):
-  ES2015 destructuring: ~16961ops/s (0.06ms/op) on 50000ops
-  immutable 3.8.2 (w/o conversion to plain JS objects): ~6538ops/s (0.15ms/op) on 50000ops
-  immutable 3.8.2 (w/ conversion to plain JS objects): ~106ops/s (9.43ms/op) on 3195ops
-  immer 0.8.1 (proxy implementation w/o autofreeze): ~2191ops/s (0.46ms/op) on 50000ops
-  immer 0.8.1 (ES5 implementation w/o autofreeze): ~494ops/s (2.02ms/op) on 14827ops
-  immutad●t 1.0.0: ~2431ops/s (0.41ms/op) on 50000ops
+  ES2015 destructuring: ~17775ops/s (0.06ms/op) on 50000ops
+  immutable 3.8.2 (w/o conversion to plain JS objects): ~6737ops/s (0.15ms/op) on 50000ops
+  immutable 3.8.2 (w/ conversion to plain JS objects): ~109ops/s (9.17ms/op) on 3274ops
+  immer 1.2.0 (proxy implementation w/o autofreeze): ~1132ops/s (0.88ms/op) on 34025ops
+  immer 1.2.0 (ES5 implementation w/o autofreeze): ~521ops/s (1.92ms/op) on 15680ops
+  qim 0.0.52: ~12042ops/s (0.08ms/op) on 50000ops
+  immutad●t 1.0.0: ~2351ops/s (0.43ms/op) on 50000ops
 Update medium todos list (10000 items):
-  ES2015 destructuring: ~1781ops/s (0.56ms/op) on 5000ops
-  immutable 3.8.2 (w/o conversion to plain JS objects): ~587ops/s (1.70ms/op) on 5000ops
-  immutable 3.8.2 (w/ conversion to plain JS objects): ~10ops/s (100.80ms/op) on 299ops
-  immer 0.8.1 (proxy implementation w/o autofreeze): ~185ops/s (5.42ms/op) on 5000ops
-  immer 0.8.1 (ES5 implementation w/o autofreeze): ~47ops/s (21.21ms/op) on 1415ops
-  immutad●t 1.0.0: ~245ops/s (4.08ms/op) on 5000ops
+  ES2015 destructuring: ~1801ops/s (0.56ms/op) on 5000ops
+  immutable 3.8.2 (w/o conversion to plain JS objects): ~630ops/s (1.59ms/op) on 5000ops
+  immutable 3.8.2 (w/ conversion to plain JS objects): ~10ops/s (95.70ms/op) on 314ops
+  immer 1.2.0 (proxy implementation w/o autofreeze): ~111ops/s (9.04ms/op) on 3319ops
+  immer 1.2.0 (ES5 implementation w/o autofreeze): ~51ops/s (19.76ms/op) on 1519ops
+  qim 0.0.52: ~1257ops/s (0.80ms/op) on 5000ops
+  immutad●t 1.0.0: ~234ops/s (4.28ms/op) on 5000ops
 Update large todos list (100000 items):
-  ES2015 destructuring: ~116ops/s (8.61ms/op) on 500ops
-  immutable 3.8.2 (w/o conversion to plain JS objects): ~56ops/s (17.95ms/op) on 500ops
-  immutable 3.8.2 (w/ conversion to plain JS objects): ~1ops/s (1052.45ms/op) on 29ops
-  immer 0.8.1 (proxy implementation w/o autofreeze): ~21ops/s (47.81ms/op) on 500ops
-  immer 0.8.1 (ES5 implementation w/o autofreeze): ~4ops/s (275.59ms/op) on 110ops
-  immutad●t 1.0.0: ~23ops/s (44.15ms/op) on 500ops
+  ES2015 destructuring: ~120ops/s (8.34ms/op) on 500ops
+  immutable 3.8.2 (w/o conversion to plain JS objects): ~58ops/s (17.28ms/op) on 500ops
+  immutable 3.8.2 (w/ conversion to plain JS objects): ~1ops/s (998.81ms/op) on 31ops
+  immer 1.2.0 (proxy implementation w/o autofreeze): ~21ops/s (48.68ms/op) on 500ops
+  immer 1.2.0 (ES5 implementation w/o autofreeze): ~4ops/s (264.16ms/op) on 114ops
+  qim 0.0.52: ~91ops/s (11.01ms/op) on 500ops
+  immutad●t 1.0.0: ~21ops/s (48.22ms/op) on 500ops
 ```
 
 ## Immutability

--- a/packages/immutadot-benchmark/package.json
+++ b/packages/immutadot-benchmark/package.json
@@ -9,7 +9,8 @@
     "immutable": "~3.8.2",
     "immutadot": "~1.0.0",
     "jest": "~21.2.1",
-    "lerna": "~2.9.0"
+    "lerna": "~2.9.0",
+    "qim": "~0.0.52"
   },
   "scripts": {
     "prebenchmark": "lerna run --scope immutadot build",

--- a/packages/immutadot-benchmark/package.json
+++ b/packages/immutadot-benchmark/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "cross-env": "~5.1.4",
-    "immer": "~1.1.3",
+    "immer": "~1.2.0",
     "immutable": "~3.8.2",
     "immutadot": "~1.0.0",
     "jest": "~21.2.1",

--- a/packages/immutadot-benchmark/src/updateTodos.spec.js
+++ b/packages/immutadot-benchmark/src/updateTodos.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { $each, $slice, set as qimSet } from 'qim'
 
 import { List, Record } from 'immutable'
 
@@ -44,6 +45,10 @@ function updateTodosList(title, listSize, modifySize, maxTime, maxOperations) {
       result.forEach(todo => todo.done ? trues++ : falses++)
       expect(trues).toBe(modifySize)
       expect(falses).toBe(unmodifiedSize)
+      trues = falses = 0
+      baseState.forEach(todo => todo.done ? trues++ : falses++)
+      expect(trues).toBe(0)
+      expect(falses).toBe(listSize)
     },
     maxTime,
     maxOperations,
@@ -84,7 +89,7 @@ function updateTodosList(title, listSize, modifySize, maxTime, maxOperations) {
   })
 
   it('immer proxy', () => {
-    benchmark('immer-proxy', 'immer 0.8.1 (proxy implementation w/o autofreeze)', () => {
+    benchmark('immer-proxy', 'immer 1.1.3 (proxy implementation w/o autofreeze)', () => {
       const [start, end] = randomBounds()
       return immer(baseState, draft => {
         for (let i = start; i < end; i++) draft[i].done = true
@@ -94,13 +99,20 @@ function updateTodosList(title, listSize, modifySize, maxTime, maxOperations) {
 
   it('immer ES5', () => {
     setUseProxies(false)
-    benchmark('immer-es5', 'immer 0.8.1 (ES5 implementation w/o autofreeze)', () => {
+    benchmark('immer-es5', 'immer 1.1.3 (ES5 implementation w/o autofreeze)', () => {
       const [start, end] = randomBounds()
       return immer(baseState, draft => {
         for (let i = start; i < end; i++) draft[i].done = true
       })
     })
     setUseProxies(true)
+  })
+
+  it('qim', () => {
+    benchmark('qim', 'qim 0.0.52', () => {
+      const [start, end] = randomBounds()
+      return qimSet([$slice(start, end), $each, 'done'], true, baseState)
+    })
   })
 
   it('immutad●t', () => {

--- a/packages/immutadot-benchmark/src/updateTodos.spec.js
+++ b/packages/immutadot-benchmark/src/updateTodos.spec.js
@@ -89,7 +89,7 @@ function updateTodosList(title, listSize, modifySize, maxTime, maxOperations) {
   })
 
   it('immer proxy', () => {
-    benchmark('immer-proxy', 'immer 1.1.3 (proxy implementation w/o autofreeze)', () => {
+    benchmark('immer-proxy', 'immer 1.2.0 (proxy implementation w/o autofreeze)', () => {
       const [start, end] = randomBounds()
       return immer(baseState, draft => {
         for (let i = start; i < end; i++) draft[i].done = true
@@ -99,7 +99,7 @@ function updateTodosList(title, listSize, modifySize, maxTime, maxOperations) {
 
   it('immer ES5', () => {
     setUseProxies(false)
-    benchmark('immer-es5', 'immer 1.1.3 (ES5 implementation w/o autofreeze)', () => {
+    benchmark('immer-es5', 'immer 1.2.0 (ES5 implementation w/o autofreeze)', () => {
       const [start, end] = randomBounds()
       return immer(baseState, draft => {
         for (let i = start; i < end; i++) draft[i].done = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,9 +2560,9 @@ ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
-immer@~1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.1.3.tgz#9d5ac1daaeadd64c587d8dae3515fc1452ea0e1e"
+immer@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-1.2.0.tgz#06a0dd9a8f8061258149f4c609250e1e5a32ffbc"
 
 immutable@~3.8.2:
   version "3.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,6 +4428,12 @@ q@^1.1.2, q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
+qim@~0.0.52:
+  version "0.0.52"
+  resolved "https://registry.yarnpkg.com/qim/-/qim-0.0.52.tgz#d18b114b3334ed32021e2f5a7badf3eab6dea188"
+  dependencies:
+    object-assign "^4.1.0"
+
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"


### PR DESCRIPTION
fix #233

Holy s**t it's fast

```
    Update small todos list (1000 items):
      ES2015 destructuring: ~11948ops/s (0.08ms/op) on 16667ops
      immutable 3.8.2 (w/o conversion to plain JS objects): ~4690ops/s (0.21ms/op) on 16667ops
      immutable 3.8.2 (w/ conversion to plain JS objects): ~96ops/s (10.38ms/op) on 964ops
      immer 1.1.3 (proxy implementation w/o autofreeze): ~1088ops/s (0.92ms/op) on 10915ops
      immer 1.1.3 (ES5 implementation w/o autofreeze): ~396ops/s (2.52ms/op) on 4013ops
      qim 0.0.52: ~8861ops/s (0.11ms/op) on 16667ops
      immutad●t 1.0.0: ~1954ops/s (0.51ms/op) on 16667ops

    Update medium todos list (10000 items):
      ES2015 destructuring: ~1264ops/s (0.79ms/op) on 1667ops
      immutable 3.8.2 (w/o conversion to plain JS objects): ~439ops/s (2.28ms/op) on 1667ops
      immutable 3.8.2 (w/ conversion to plain JS objects): ~9ops/s (105.55ms/op) on 96ops
      immer 1.1.3 (proxy implementation w/o autofreeze): ~165ops/s (6.05ms/op) on 1654ops
      immer 1.1.3 (ES5 implementation w/o autofreeze): ~39ops/s (25.88ms/op) on 387ops
      qim 0.0.52: ~908ops/s (1.10ms/op) on 1667ops
      immutad●t 1.0.0: ~192ops/s (5.21ms/op) on 1667ops

    Update large todos list (100000 items):
      ES2015 destructuring: ~84ops/s (11.88ms/op) on 167ops
      immutable 3.8.2 (w/o conversion to plain JS objects): ~42ops/s (23.96ms/op) on 167ops
      immutable 3.8.2 (w/ conversion to plain JS objects): ~1ops/s (1076.30ms/op) on 10ops
      immer 1.1.3 (proxy implementation w/o autofreeze): ~14ops/s (73.28ms/op) on 137ops
      immer 1.1.3 (ES5 implementation w/o autofreeze): ~3ops/s (348.28ms/op) on 29ops
      qim 0.0.52: ~69ops/s (14.51ms/op) on 167ops
      immutad●t 1.0.0: ~17ops/s (58.50ms/op) on 167ops
```